### PR TITLE
Activity間のクラスの引き渡しお試し実装 #10

### DIFF
--- a/app/src/main/java/com/example/gomoku/GameActivity.kt
+++ b/app/src/main/java/com/example/gomoku/GameActivity.kt
@@ -8,9 +8,7 @@ import android.graphics.Point
 import android.os.Bundle
 import android.view.View
 import android.view.WindowManager
-import android.widget.Button
-import android.widget.TableLayout
-import android.widget.TableRow
+import android.widget.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 
@@ -25,6 +23,25 @@ class GameActivity : AppCompatActivity() {
 
         // 基盤の初期化
         initBoard();
+
+        val setting = intent.getSerializableExtra("SETTING")
+        if(setting is Setting) {
+            findViewById<LinearLayout>(R.id.displayLinear).also { linearLayout ->
+                val textView = TextView(this)
+                textView.setText("board  = " + setting.board.toString())
+                linearLayout.addView(textView, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+            }
+            findViewById<LinearLayout>(R.id.displayLinear).also { linearLayout ->
+                val textView = TextView(this)
+                textView.setText("rule33 = " + setting.rule33.toString())
+                linearLayout.addView(textView, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+            }
+            findViewById<LinearLayout>(R.id.displayLinear).also { linearLayout ->
+                val textView = TextView(this)
+                textView.setText("rule44 = " + setting.rule44.toString())
+                linearLayout.addView(textView, LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+            }
+        }
     }
 
     private val MAX_ROW = 13 // 最大 '行' 数(横方向)

--- a/app/src/main/java/com/example/gomoku/MainActivity.kt
+++ b/app/src/main/java/com/example/gomoku/MainActivity.kt
@@ -12,6 +12,10 @@ class MainActivity : AppCompatActivity() {
 
         startButton.setOnClickListener {
             val intent = Intent(applicationContext, GameActivity::class.java)
+
+            val setting = Setting(13, false, true)
+            intent.putExtra("SETTING", setting)
+
             startActivity(intent)
         }
     }

--- a/app/src/main/java/com/example/gomoku/Setting.kt
+++ b/app/src/main/java/com/example/gomoku/Setting.kt
@@ -1,0 +1,9 @@
+package com.example.gomoku
+
+import java.io.Serializable
+
+class Setting (
+    var board: Int,
+    var rule33: Boolean,
+    var rule44: Boolean
+): Serializable


### PR DESCRIPTION
※当該プルリクエストはマージしません。ご参考までに

Activity間でのクラス渡しのお試し実装です。
スタート画面で設定クラスを生成し、ゲーム画面に渡して、クラスの内容を画面表示しています。